### PR TITLE
doc : gravatar à 80 par défaut

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -155,7 +155,7 @@ type d'urls: _seenthis_
 
 ## gravatar:
 [http://localhost/seenthis/ecrire/?exec=configurer_gravatar](http://localhost/seenthis/ecrire/?exec=configurer_gravatar)
-=> saisir 48 pour la dimension
+=> saisir 80 pour la dimension
 
 ## moteur de recherche fulltext:
 ```


### PR DESCRIPTION
conseiller 80 pour la taille par défaut des gravatars pour avoir un logo d'auteur à la même taille dans les deux cas (gravatart/logo perso)