### PR TITLE
compat mysql < 5.6

### DIFF
--- a/tables.sql
+++ b/tables.sql
@@ -462,7 +462,7 @@ CREATE TABLE `spip_me_tags` (
   `uuid` char(36) NOT NULL DEFAULT '',
   `tag` text NOT NULL,
   `class` char(6) NOT NULL DEFAULT '',
-  `date` datetime NOT NULL default '0000-00-00 00:00:00' on update CURRENT_TIMESTAMP,
+  `date` datetime NOT NULL default '0000-00-00 00:00:00',
   `relevance` int(11) NOT NULL,
   `off` char(3) NOT NULL DEFAULT 'non',
   KEY `uuid` (`uuid`),


### PR DESCRIPTION
on update CURRENT_TIMESTAMP sur un champ de type datetime n'est pas dispo en mysql < 5.6, du coup l'import du dump génèrait une erreur