### PR TITLE
Notif block

### DIFF
--- a/inc/seenthis_notifier.php
+++ b/inc/seenthis_notifier.php
@@ -39,7 +39,7 @@ function notifier_partage($id_auteur_partage, $id_me) {
 		return;
 	}
 
-	$query_aut_partage = sql_select("*", "spip_auteurs", "id_auteur = $id_auteur_partage");
+	$query_aut_partage = sql_select("*", "spip_auteurs", "id_auteur = $id_auteur_partage AND id_auteur NOT IN (select id_auteur FROM spip_me_block WHERE id_block IN($id_auteur_partage, id_auteur))");
 	$row_aut_partage = sql_fetch($query_aut_partage);
 	if (!$row_aut_partage) {
 		return;

--- a/inc/seenthis_notifier.php
+++ b/inc/seenthis_notifier.php
@@ -39,7 +39,7 @@ function notifier_partage($id_auteur_partage, $id_me) {
 		return;
 	}
 
-	$query_aut_partage = sql_select("*", "spip_auteurs", "id_auteur = $id_auteur_partage AND id_auteur NOT IN (select id_auteur FROM spip_me_block WHERE id_block IN($id_auteur_partage, id_auteur))");
+	$query_aut_partage = sql_select("*", "spip_auteurs", "id_auteur = $id_auteur_partage AND id_auteur NOT IN (select id_auteur FROM spip_me_block WHERE id_block = $id_auteur)");
 	$row_aut_partage = sql_fetch($query_aut_partage);
 	if (!$row_aut_partage) {
 		return;

--- a/inc/seenthis_notifier.php
+++ b/inc/seenthis_notifier.php
@@ -234,6 +234,8 @@ function notifier_me($id_me, $id_parent) {
 				$id_dest[] = $id_auteur;
 			}
 		}
+	} else {
+		$id_auteur = 0;
 	}
 
 	// destinataires cités dans le message ; sauf s'ils bloquent l'auteur
@@ -271,12 +273,22 @@ function notifier_me($id_me, $id_parent) {
 		)
 	);
 
-	// toutes les raisons precedentes ne doivent jamais envoyer a l'auteur.e
-	// lui-meme : on filtre
-	foreach ($id_dest as $k => $id) {
-		if ($id == $id_auteur_me)
-			unset($id_dest[$k]);
+	// ne pas envoyer vers soi-même
+	$remove = [$id_auteur_me];
+
+	// ni vers les comptes bloques
+	$s = sql_query($q = 'SELECT id_auteur FROM spip_me_block WHERE id_block IN (' . sql_quote($id_auteur_me).','.sql_quote($id_auteur).')');
+	while ($t = sql_fetch($s)) {
+		$remove[] = $t['id_auteur'];
 	}
+
+	foreach ($remove as $id_r) {
+		foreach ($id_dest as $k => $id) {
+			if ($id == $id_r)
+				unset($id_dest[$k]);
+		}
+	}
+
 
 	// Ajouter l'auteur.e du message si elle a coche la case correspondante
 	if (tester_mail_auteur($id_auteur_me, "mail_mes_billets")) {


### PR DESCRIPTION
- ne pas envoyer de notification de partage vers des auteurs bloqués par l'auteur du message ou par l'auteur du partage
- ne pas envoyer de notification de nouveau message vers un auteur bloqué par l'auteur du fil ou l'auteur du message