### PR TITLE
version 2.3.6 : le champ viarss est pris en charge par seenthis et no…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@
 
 Seenthis fonctionne comme un site SPIP classique, avec une base de données de type MySQL, des scripts en PHP et des squelettes SPIP.
 
-Les utilisateurs sont enregistrés dans la table normale des auteurs de SPIP ; quelques champs supplémentaires permettent de conserver leurs informations de configuration.
+Les utilisateurs sont enregistrés dans la table normale des auteurs de SPIP ; quelques champs supplémentaires permettent de conserver leurs informations de configuration.
 
 Une table annexe spip_me_follow permet d'enregistrer la structure du réseau social (qui suit qui).
 
@@ -52,7 +52,6 @@ git clone https://git.spip.net/spip-contrib-extensions/typo_guillemets.git
 
 git clone https://github.com/seenthis/seenthis.git
 git clone https://github.com/seenthis/seenthis_squelettes.git
-git clone https://github.com/seenthis/seenthis_importer_flux.git
 ```
 
 
@@ -74,7 +73,6 @@ Si tout va bien, voici la liste des plugins présents :
 * saisies
 * seenthis
 * seenthis_squelettes
-* seenthis_importer_flux
 * soundmanager
 * typo_guillemets
 
@@ -88,6 +86,7 @@ On active alors la connexion SQL du site SPIP :
 Activer tous les plugins pré-cités, sauf :
 * OpenSearch
 * option = activer seenthis_opencalais
+* option = activer seenthis_importer_flux
 
 Créer un fichier `config/mes_options.php` :
 
@@ -164,6 +163,14 @@ ALTER TABLE spip_syndic ADD FULLTEXT tout (`url_site`,`titre`,`texte`);
 
 
 # Ajout des plugins optionnels 
+
+## seenthis_importer_flux
+
+Ce plugin ajoute un champ 'rss' dans spip_auteurs, et une tâche cron qui charge ce RSS et le transforme en seens (et en partages si l'URL est déjà mentionnée dans un autre seen).
+```
+git clone https://github.com/seenthis/seenthis_importer_flux.git
+```
+
 
 ## seenthis_opencalais
 

--- a/base/seenthis.php
+++ b/base/seenthis.php
@@ -63,6 +63,7 @@ function seenthis_declarer_tables_principales($tables_principales){
 		`ip` varchar(40) NOT NULL,
 		`id_dest` bigint(21) NOT NULL,
 		`troll` bigint(21) NOT NULL,
+		`viarss` tinyint(1) NOT NULL DEFAULT '0',
 		PRIMARY KEY (`id_me`),
 		KEY `uuid` (`uuid`),
 		KEY `id_auteur` (`id_auteur`),

--- a/paquet.xml
+++ b/paquet.xml
@@ -1,10 +1,10 @@
 <paquet
 	prefix="seenthis"
 	categorie="divers"
-	version="2.3.5"
+	version="2.3.6"
 	etat="stable"
 	compatibilite="[3.1.0;["
-	schema="1.1.10"
+	schema="1.1.11"
 	logo="prive/logo/logo_seenthis.png"
 >	
 

--- a/seenthis_administrations.php
+++ b/seenthis_administrations.php
@@ -78,6 +78,10 @@ function seenthis_upgrade($nom_meta_base_version,$version_cible){
 	$maj['1.1.9'] = array(
 		array('maj_tables', array('spip_auteurs')),
 	);
+	// en 1.1.11, poser viarss sur spip_me
+	$maj['1.1.11'] = array(
+		array('maj_tables', array('spip_me')),
+	);
 
 	include_spip('base/upgrade');
 	maj_plugin($nom_meta_base_version, $version_cible, $maj);


### PR DESCRIPTION
…n le plugin importer_flux (core)

ref https://github.com/seenthis/seenthis_squelettes/issues/177 & https://github.com/seenthis/seenthis/pull/34